### PR TITLE
Add GH action to test RPM build on new PR commit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,7 @@
+name: Test build env
+
+on: [push]
+
+jobs:
+  call-test-rpm-build:
+    uses: xcp-ng-rpms/test-rpm-build/.github/workflows/test-rpm-build.yaml@create-reusable-workflow


### PR DESCRIPTION
The action copy the [test-rpm-build](https://github.com/xcp-ng-rpms/test-rpm-build/) repo and run its test script.

Assume the git describe will respect the format: `<XCP-ng Version>-<nb of ahead commits>-<hash>`
It means a previous XCP-ng release must be tagged in the history tree.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>